### PR TITLE
WS has a bug, when an error accures no echo_req will be returned. thi…

### DIFF
--- a/src/websockets/eventSourceHandler.js
+++ b/src/websockets/eventSourceHandler.js
@@ -39,14 +39,24 @@ define(['es6-promise', 'reconnecting-websocket', 'jquery-timer'], function (es6_
             cb(data);
         });
 
-        var key = data.echo_req.passthrough && data.echo_req.passthrough.uid;
-        if(key){
+        if (!data.error) {
+            var key = data.echo_req.passthrough && data.echo_req.passthrough.uid;
+            var promise = unresolved_promises[key];
+            if (promise) {
+                delete unresolved_promises[key];
+                promise.resolve(data);
+            }
+        }
+        /* WS has bug, when an error accures no echo_req will be returned.
+           This needs to be fixed because we can't know which promise should be rejected.
+           As a TEMPORARY WORKAROUND :
+               requests are returned in FIFO order (not documented), we will reject the first promise.
+        */
+        else {
+            var key = Object.keys(unresolved_promises)[0];
             var promise = unresolved_promises[key];
             delete unresolved_promises[key];
-            if(promise) {
-                data.error ?
-                    promise.reject(data.error) : promise.resolve(data);
-            }
+            promise.reject(data.error);
         }
     }
 


### PR DESCRIPTION
…s needs to be fixed, We cant tell which promise should be rejected. As a TEMPORARY WORKAROUND because requests are returned in FIFO order(not documented), we will reject the first one