### PR TITLE
Renaming Tile to Tile Charts

### DIFF
--- a/src/navigation/navigation.html
+++ b/src/navigation/navigation.html
@@ -45,7 +45,7 @@
         <li class="windows">
             <a href="#" class="nav-dropdown-toggle">Windows <span class="nav-caret"></span></a>
             <ul>
-                <li><a href="#" class="tile">Tile</a></li>
+                <li><a href="#" class="tile">Tile charts</a></li>
                 <li><a href="#" class="closeAll">Close all</a></li>
             </ul>
         </li>


### PR DESCRIPTION
Renaming Tile to Tile Charts because we are only tiling charts. Other windows retain their position.