### PR TITLE
Do not miss ticks when shwoing tick live confirmation.

### DIFF
--- a/src/navigation/navigation.html
+++ b/src/navigation/navigation.html
@@ -9,9 +9,9 @@
     <span id="mobile-menu-heading">Binary.com</span>
     <!-- navigation menu -->
     <ul id="nav-menu" class="nav-normal-menu">
-        <!-- <li class="trade">
+        <li class="trade">
             <a href="#" class="nav-dropdown-toggle">Trade <span class="nav-caret"></span></a>
-        </li> -->
+        </li>
         <li class="instruments">
             <a href="#" class="nav-dropdown-toggle">Chart <span class="nav-caret"></span></a>
         </li>

--- a/src/trade/tradeConf.js
+++ b/src/trade/tradeConf.js
@@ -2,9 +2,11 @@
  * Created by amin on December 4, 2015.
  */
 
-define(['lodash', 'jquery', 'moment', 'websockets/binary_websockets', 'common/rivetsExtra', 'text!trade/tradeConf.html', 'css!trade/tradeConf.css' ],
-  function(_, $, moment, liveapi, rv, html){
+define(['lodash', 'jquery', 'moment', 'websockets/binary_websockets', 'common/rivetsExtra', 'charts/chartingRequestMap', 'text!trade/tradeConf.html', 'css!trade/tradeConf.css' ],
+  function(_, $, moment, liveapi, rv, chartingRequestMap, html){
 
+    require(['websockets/stream_handler']);
+    var barsTable = chartingRequestMap.barsTable;
     /* rv binder to show tick chart for this confirmation dialog */
     rv.binders['tick-chart'] = {
       priority: 65, /* a low priority to apply last */
@@ -86,10 +88,7 @@ define(['lodash', 'jquery', 'moment', 'websockets/binary_websockets', 'common/ri
                although we will automatically resubscribe (in binary_websockets),
                BUT we will also lose some ticks in between!
                which means we ware showing the wrong ticks to the user! FIX THIS*/
-      var fn = liveapi.events.on('tick', function (data) {
-          if (tick_count === 0 || !data.tick || data.tick.symbol !== symbol || data.tick.epoch * 1 < purchase_epoch)
-            return;
-          var tick = data.tick;
+      function add_tick(tick){
           state.ticks.array.push({
             quote: tick.quote,
             epoch: tick.epoch,
@@ -107,6 +106,19 @@ define(['lodash', 'jquery', 'moment', 'websockets/binary_websockets', 'common/ri
           /* update state for each new tick in Up/Down && Asians contracts */
           if(state.ticks.category !== 'Digits')
               state.ticks.update_status();
+      }
+      var key = chartingRequestMap.keyFor(symbol, 0);
+      var ticks  = barsTable.find({instrumentCdAndTp: key});
+      var start_time = state.buy.start_time*1000;
+      ticks = ticks.filter(function(tick) { return tick.time > start_time; })
+                   .map(function(tick) { return {quote: tick.open, epoch: tick.time/1000 }; })
+                   .sort(function(a,b) { return a.epoch - b.epoch; });
+      ticks.forEach(add_tick); /* add existing ticks */
+
+      var fn = liveapi.events.on('tick', function (data) {
+          if (tick_count === 0 || !data.tick || data.tick.symbol !== symbol || data.tick.epoch * 1 < purchase_epoch)
+            return;
+          add_tick(data.tick);
       });
     }
 
@@ -171,7 +183,7 @@ define(['lodash', 'jquery', 'moment', 'websockets/binary_websockets', 'common/ri
             chart_visible: extra.show_tick_chart,
         },
         arrow: {
-          visible: !extra.show_tick_chart,
+          visible: !extra.show_tick_chart && extra.category !== 'Digits',
         },
         back: { visible: false }, /* back buttom */
       };

--- a/src/trade/tradeDialog.js
+++ b/src/trade/tradeDialog.js
@@ -622,9 +622,10 @@ define(['lodash', 'jquery', 'moment', 'windows/windows', 'common/rivetsExtra', '
         if(_(['Digits','Up/Down','Asians']).includes(extra.category) && state.duration.value === 'Duration' && extra.duration_unit === 'ticks') {
             extra.digits_value = state.digits.value;
             extra.tick_count = state.duration_count.value*1;
-            if(extra.category !== 'Digits')
+            if(extra.category !== 'Digits') {
               extra.tick_count += 1; /* we are shwoing X ticks arfter the initial tick so the total will be X+1 */
-            extra.show_tick_chart = true;
+              extra.show_tick_chart = true;
+            }
         }
 
         // manually check to see if the user is authenticated or not,

--- a/src/viewtransaction/viewTransaction.js
+++ b/src/viewtransaction/viewTransaction.js
@@ -162,6 +162,8 @@ define(["jquery", "windows/windows", "websockets/binary_websockets", "portfolio/
         contract.is_expired = 1;
         contract.is_valid_to_sell = 0;
       }
+      if(contract.is_expired)
+        contract.is_valid_to_sell = 0;
 
       if(contract.validation_error)
         state.validation = contract.validation_error;

--- a/src/websockets/stream_handler.js
+++ b/src/websockets/stream_handler.js
@@ -23,14 +23,16 @@ define(["websockets/binary_websockets", "charts/chartingRequestMap", "common/uti
             var time = parseInt(data.tick.epoch) * 1000;
 
             var chartingRequest = chartingRequestMap[key];
-            chartingRequest.id = chartingRequest.id || data.tick.id;
-            if (!(chartingRequest.chartIDs && chartingRequest.chartIDs.length > 0))
-                return;
-            var timePeriod = $(chartingRequest.chartIDs[0].containerIDWithHash).data('timePeriod');
-            if (!timePeriod)
-                return;
+            var granularity = data.echo_req.granularity || 0;
+            // chartingRequest.id = chartingRequest.id || data.tick.id;
+            // if (!(chartingRequest.chartIDs && chartingRequest.chartIDs.length > 0))
+                // return;
+            // var timePeriod = $(chartingRequest.chartIDs[0].containerIDWithHash).data('timePeriod');
+            // if (!timePeriod)
+                // return;
 
-            if (isTick(timePeriod)) { //Update OHLC with same value in DB
+            // if (isTick(timePeriod)) { //Update OHLC with same value in DB
+            if(granularity === 0) {
                 var tick = {
                   instrumentCdAndTp: key,
                   time: time,
@@ -43,6 +45,9 @@ define(["websockets/binary_websockets", "charts/chartingRequestMap", "common/uti
                 /* notify subscribers */
                 fire_event('tick', {tick: tick, key: key});
 
+                if (!(chartingRequest.chartIDs && chartingRequest.chartIDs.length > 0)) {
+                    return;
+                }
                 //notify all registered charts
                 chartingRequest.chartIDs.forEach(function (chartID) {
                     var chart = $(chartID.containerIDWithHash).highcharts();


### PR DESCRIPTION
I was not able to reproduce the issue directly, but after manually delaying creation of confrim dialog i saw that some ticks are missing.
this pr tries not to miss any previous ticks by checking *barstable* first.