### PR TITLE
Set expiration date for webtrader_token cookie

### DIFF
--- a/src/websockets/binary_websockets.js
+++ b/src/websockets/binary_websockets.js
@@ -163,7 +163,7 @@ define(['jquery'], function ($) {
 
         return promise
             .then(function (val) {
-                Cookies.set('webtrader_token', token, { expires: 1 }); /* never expiers */
+                Cookies.set('webtrader_token', token, { expires: 365 }); /* never expiers */
                 is_authenitcated_session = true;
                 fire_event('login', val);
                 auth_successfull = true;

--- a/src/websockets/binary_websockets.js
+++ b/src/websockets/binary_websockets.js
@@ -163,7 +163,7 @@ define(['jquery'], function ($) {
 
         return promise
             .then(function (val) {
-                Cookies.set('webtrader_token', token); /* never expiers */
+                Cookies.set('webtrader_token', token, { expires: 1 }); /* never expiers */
                 is_authenitcated_session = true;
                 fire_event('login', val);
                 auth_successfull = true;


### PR DESCRIPTION
@arnabk We are using js-cookie to set the cookie and by default it removes the cookie when the user closes the browser, but we can define when the cookie will be removed. Value can be a number which will be interpreted as days from time of creation or a date instance, that i set it to 1 day.
