### PR TITLE
Fix NAN for final-price

### DIFF
--- a/src/viewtransaction/viewTransaction.js
+++ b/src/viewtransaction/viewTransaction.js
@@ -239,7 +239,7 @@ define(["jquery", "windows/windows", "websockets/binary_websockets", "charts/cha
         state.table.sell_spot = contract.sell_spot;
         state.table.sell_time = contract.sell_time;
         state.table.sell_price = contract.sell_price;
-        state.table.final_price = formatPrice(contract.sell_price);
+        state.table.final_price = contract.sell_price;
       }
 
         if(!state.chart.barrier && contract.barrier) {


### PR DESCRIPTION
Removed `formatPrice` on `contract.sell_price` because we are already formatting the price from html using rivets.