### PR TITLE
Fix typo in chart template manager

### DIFF
--- a/src/charts/chartTemplateManager.es6
+++ b/src/charts/chartTemplateManager.es6
@@ -82,7 +82,7 @@ define(['jquery', 'charts/chartWindow', 'common/rivetsExtra'], function($, chart
         local_storage.set('templates', array);
         templates.array = array;
         templates.current = current;
-        $.growl.notice({message: 'Template changes saved '.i18n() + '(' + current.name + ')')});
+        $.growl.notice({message: 'Template changes saved '.i18n() + '(' + current.name + ')'});
       }
 
       menu.open_file_selector = (event) => {


### PR DESCRIPTION
@arnabk this is an erron on my side, i guess while reviewing the code i mistakenly added the parentheses `)`. It is causing an error while deployment.

I will be carefull next-time.