### PR TITLE
Opera unsupported

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -98,7 +98,10 @@ require(["jquery", 'text!i18n/' + i18n_name + '.json', "modernizr"], function( $
     if (i18n_name == 'ar') {
       $('body').addClass('rtl-direction');
     }
-
+    console.log(1);
+    setTimeout(function(){
+        console.log(!Modernizr.svg, !Modernizr.websockets, (Modernizr.touch && isSmallView() && !isAffiliates()), !Modernizr.localstorage, !Modernizr.webworkers)
+    },0);
     //By pass touch check for affiliates=true(because they just embed our charts)
     if (!Modernizr.svg || !Modernizr.websockets || (Modernizr.touch && isSmallView() && !isAffiliates()) || !Modernizr.localstorage || !Modernizr.webworkers) {
       window.location.href = 'unsupported_browsers/unsupported_browsers.html';

--- a/src/main.js
+++ b/src/main.js
@@ -87,25 +87,24 @@ requirejs.onError = function (err) {
     throw err;
 };
 
+require(['modernizr'], function(){
+    //By pass touch check for affiliates=true(because they just embed our charts)
+    if (!Modernizr.svg || !Modernizr.websockets || (Modernizr.touch && isSmallView() && !isAffiliates()) || !Modernizr.localstorage || !Modernizr.webworkers || !Object.defineProperty) {
+      window.location.href = 'unsupported_browsers/unsupported_browsers.html';
+      return;
+    }
+})
+
 /* Initialize the websocket as soon as possible */
 require(['websockets/binary_websockets','text!oauth/app_id.json']);
 
 var i18n_name = (local_storage.get('i18n') || { value: 'en' }).value;
-require(["jquery", 'text!i18n/' + i18n_name + '.json', "modernizr"], function( $, lang_json) {
+require(["jquery", 'text!i18n/' + i18n_name + '.json'], function( $, lang_json) {
     "use strict";
     /* setup translating string literals */
     setup_i18n_translation(JSON.parse(lang_json));
     if (i18n_name == 'ar') {
       $('body').addClass('rtl-direction');
-    }
-    console.log(1);
-    setTimeout(function(){
-        console.log(!Modernizr.svg, !Modernizr.websockets, (Modernizr.touch && isSmallView() && !isAffiliates()), !Modernizr.localstorage, !Modernizr.webworkers)
-    },0);
-    //By pass touch check for affiliates=true(because they just embed our charts)
-    if (!Modernizr.svg || !Modernizr.websockets || (Modernizr.touch && isSmallView() && !isAffiliates()) || !Modernizr.localstorage || !Modernizr.webworkers) {
-      window.location.href = 'unsupported_browsers/unsupported_browsers.html';
-      return;
     }
 
     /* Trigger *Parallel* loading of big .js files,

--- a/src/unsupported_browsers/unsupported_browsers.html
+++ b/src/unsupported_browsers/unsupported_browsers.html
@@ -29,6 +29,10 @@
 			document.getElementsByClassName("logo")[0].style.width="100%";
 			document.getElementsByClassName("logo")[0].childNodes[1].src = "../images/binary-symbol-logo.png";
 		}
+
+		if(!Object.defineProperty){
+			document.getElementsByClassName("logo")[0].style.width="50px";
+		}
 	}
 	</script>
 </head>


### PR DESCRIPTION
jQuery is not supported in Opera v11. Moved the check for compatibility outside the jquery block to successfully check for compatible browsers.