### PR TITLE
oskar/ticktrade_addcomma_exitspot

### DIFF
--- a/src/common/util.js
+++ b/src/common/util.js
@@ -1,7 +1,3 @@
-/**
- * Created by arnab on 2/12/15.
- */
-
 function isTick(ohlc) {
     return ohlc.indexOf("t") !== -1;
 }
@@ -120,6 +116,20 @@ function formatPrice(float, currency) {
     }
 	return float;
 }
+
+function addComma(num, decimal_points, is_crypto) {
+    let number = String(num || 0).replace(/,/g, '');
+    if (typeof decimal_points !== 'undefined') {
+        number = (+number).toFixed(decimal_points);
+    }
+    if (is_crypto) {
+        number = parseFloat(+number);
+    }
+
+    return number.toString().replace(/(^|[^\w.])(\d{4,})/g, ($0, $1, $2) => (
+        $1 + $2.replace(/\d(?=(?:\d\d\d)+(?!\d))/g, '$&,')
+    ));
+};
 
 function sortAlphaNum(property) {
     "use strict";

--- a/src/common/util.js
+++ b/src/common/util.js
@@ -118,7 +118,7 @@ function formatPrice(float, currency) {
 }
 
 function addComma(num, decimal_points, is_crypto) {
-    let number = String(num || 0).replace(/,/g, '');
+    var number = String(num || 0).replace(/,/g, '');
     if (typeof decimal_points !== 'undefined') {
         number = (+number).toFixed(decimal_points);
     }
@@ -126,9 +126,9 @@ function addComma(num, decimal_points, is_crypto) {
         number = parseFloat(+number);
     }
 
-    return number.toString().replace(/(^|[^\w.])(\d{4,})/g, ($0, $1, $2) => (
-        $1 + $2.replace(/\d(?=(?:\d\d\d)+(?!\d))/g, '$&,')
-    ));
+    return number.toString().replace(/(^|[^\w.])(\d{4,})/g, function($0, $1, $2) {
+        return $1 + $2.replace(/\d(?=(?:\d\d\d)+(?!\d))/g, '$&,')
+    });
 };
 
 function sortAlphaNum(property) {

--- a/src/trade/tradeConf.es6
+++ b/src/trade/tradeConf.es6
@@ -7,8 +7,10 @@ import chartingRequestMap from '../charts/chartingRequestMap';
 import html from 'text!../trade/tradeConf.html';
 import 'css!../trade/tradeConf.css';
 import Lookback from './lookback';
+import '../common/util';
 
 /* rv binder to show tick chart for this confirmation dialog */
+let display_decimals;
 rv.binders['tick-chart'] = {
    priority: 65, /* a low priority to apply last */
    bind: function(el) {
@@ -37,7 +39,13 @@ rv.binders['tick-chart'] = {
             labels: { enabled: false, }
          },
          yAxis: {
-            labels: { align: 'left', x: 0, },
+            labels: {
+                  align: 'left',
+                  x: 0,
+                  formatter() {
+                        return addComma(this.value.toFixed(display_decimals));
+                  },
+            },
             title: '',
             gridLineWidth: 0,
          },
@@ -79,7 +87,6 @@ rv.binders['tick-chart'] = {
             color: 'green',
             width: 2,
          });
-
          /* Add plotline value to invisible seri to make the plotline always visible. */
          chart.series[1].addPoint([1, options.value*1]);
       };
@@ -88,14 +95,14 @@ rv.binders['tick-chart'] = {
       if(index == 0) return;
 
       const tick = _.last(ticks);
-      el.chart.series[0].addPoint([index, tick.quote*1]);
+      el.chart.series[0].addPoint([index, tick.quote]);
 
       const plot_x = model.getPlotX(); // could return null
       plot_x && addPlotLineX(el.chart,plot_x);
       const plot_y = model.getPlotY(); // could return null
       plot_y && el.chart.yAxis[0].removePlotLine(plot_y.id);
       plot_y && addPlotLineY(el.chart, plot_y);
-
+      console.log(el.chart.series[0].data);
    } /* end of routine() */
 };
 
@@ -205,6 +212,7 @@ const register_ticks = (state, extra) => {
 * @param hide_callback
 **/
 export const init = (data, extra, show_callback, hide_callback) => {
+   display_decimals = data.display_decimals || 2;
    const root = $(html).i18n();
    const buy = data.buy;
    const decimal_digits = chartingRequestMap.digits_after_decimal(extra.pip, extra.symbol);

--- a/src/trade/tradeConf.es6
+++ b/src/trade/tradeConf.es6
@@ -225,7 +225,7 @@ const register_ticks = (state, extra) => {
             }
 
             ({ proposal_open_contract } = data);
-      });
+   });
    
   let temp_ticks = [];
   on_tick = liveapi.events.on('tick', (data) => {
@@ -239,7 +239,7 @@ const register_ticks = (state, extra) => {
       }
 
       if (temp_ticks.length > 0) {
-            temp_ticks.forEach((x) => add_tick(x));
+            temp_ticks.forEach((stored_tick) => add_tick(stored_tick));
             temp_ticks = [];
       }
 

--- a/src/trade/tradeConf.es6
+++ b/src/trade/tradeConf.es6
@@ -152,17 +152,19 @@ const register_ticks = (state, extra) => {
             if (contract_is_finished) {
                   on_contract_finished(proposal_open_contract);
             }
-            on_add_new_tick_to_chart(tick);
+            add_tick_to_state(tick);
       }
    }
 
-   const on_add_new_tick_to_chart = (tick) => {
+   const add_tick_to_state = (tick) => {
       const decimal_digits = chartingRequestMap.digits_after_decimal(extra.pip, extra.symbol);
+      const tooltip = make_tooltip(tick);
+
       state.ticks.array.push({
          quote: (+tick.quote),
          epoch: (+tick.epoch),
          number: state.ticks.array.length + 1,
-         tooltip: make_tooltip(tick),
+         tooltip,
          decimal_digits,
       });
 

--- a/src/trade/tradeConf.es6
+++ b/src/trade/tradeConf.es6
@@ -92,7 +92,7 @@ rv.binders['tick-chart'] = {
             const exit_tick_idx = model.exit_tick && (ticks.findIndex((tick) => tick.quote === +model.exit_tick)) + 1;
             const exit_spot_idx = exit_tick_idx ? exit_tick_idx : (tick_idx - 1);
             const exit_spot = model.make_exit_spot(exit_spot_idx);
-            draw_x_line_chart(el.chart, exit_spot);
+            draw_x_line(el.chart, exit_spot);
       };
 
       function draw_tick(tick_idx) {
@@ -103,15 +103,15 @@ rv.binders['tick-chart'] = {
       function draw_entry_spot(tick_idx) {
             const is_label_left = true;
             const entry_spot = model.make_entry_spot(tick_idx);
-            draw_x_line_chart(el.chart, entry_spot, is_label_left);
+            draw_x_line(el.chart, entry_spot, is_label_left);
       };
 
       function draw_barrier(barrier) {
             el.chart.yAxis[0].removePlotLine(barrier.id);
-            draw_y_line_chart(el.chart, barrier);
+            draw_y_line(el.chart, barrier);
       };
 
-      function draw_x_line_chart(chart, options, align_label_left) {
+      function draw_x_line(chart, options, align_label_left) {
             const label_x_position = align_label_left ? -15 : 5;
    
             chart.xAxis[0].addPlotLine({
@@ -124,7 +124,7 @@ rv.binders['tick-chart'] = {
             });
       };
 
-      function draw_y_line_chart(chart,options) {
+      function draw_y_line(chart,options) {
             chart.yAxis[0].addPlotLine({
                id: options.id || options.label,
                value: options.value,
@@ -173,6 +173,7 @@ const register_ticks = (state, extra) => {
             const tick_time = moment.utc(tick.epoch*1000).format('dddd, MMM D, HH:mm:ss');
             const { symbol_name } = extra;
             const tick_quote_formatted = (+tick.quote).toFixed(decimal_digits);
+
             return `${tick_time}<br/>${symbol_name} ${(+tick.quote).toFixed(decimal_digits)}`;
       };
    };

--- a/src/trade/tradeConf.es6
+++ b/src/trade/tradeConf.es6
@@ -102,8 +102,7 @@ rv.binders['tick-chart'] = {
       const plot_y = model.getPlotY(); // could return null
       plot_y && el.chart.yAxis[0].removePlotLine(plot_y.id);
       plot_y && addPlotLineY(el.chart, plot_y);
-      console.log(el.chart.series[0].data);
-   } /* end of routine() */
+   }
 };
 
 const last_1000_ticks = []; /* record the last 1k ticks returned */
@@ -212,7 +211,7 @@ const register_ticks = (state, extra) => {
 * @param hide_callback
 **/
 export const init = (data, extra, show_callback, hide_callback) => {
-   display_decimals = data.display_decimals || 2;
+   display_decimals = data.display_decimals || 3;
    const root = $(html).i18n();
    const buy = data.buy;
    const decimal_digits = chartingRequestMap.digits_after_decimal(extra.pip, extra.symbol);

--- a/src/trade/tradeConf.es6
+++ b/src/trade/tradeConf.es6
@@ -68,7 +68,7 @@ rv.binders['tick-chart'] = {
       // Handles updating chart: state.ticks.array updates => routine fires
       const model = this.model;
       const tick_idx = ticks.length;
-      const barrier = model.getBarrier();
+      const barrier = model.make_barrier();
       const { contract_is_finished } = model;
 
       if (tick_idx === 0) return;
@@ -196,7 +196,8 @@ const register_ticks = (state, extra) => {
             on_open_proposal_error(data);
             return;
       }
-      on_open_proposal_success(data);
+
+      contract = data.proposal_open_contract;
    });
 
    liveapi.events.on('tick', (data) => {
@@ -210,10 +211,6 @@ const register_ticks = (state, extra) => {
       $.growl.error({message: data.error.message});
       liveapi.proposal_open_contract.forget(data.echo_req.contract_id);
       liveapi.proposal_open_contract.subscribe(data.echo_req.contract_id);
-   };
-
-   const on_open_proposal_success = (data) => {
-      contract = data.proposal_open_contract;
    };
 }
 
@@ -264,7 +261,7 @@ export const init = (data, extra, show_callback, hide_callback) => {
          exit_tick: null,
          make_exit_spot: (inx) => ({value: inx, label: 'Exit Spot'.i18n(), dashStyle: 'Dash'}),
          make_entry_spot: (inx) => ({value: inx, label: 'Entry Spot'.i18n()}),
-         getBarrier: () => {
+         make_barrier: () => {
             const { barrier } = state.buy;
             return { value: +barrier, label: 'Barrier ('.i18n() + barrier + ')', id: 'plot-barrier-y'};
          },

--- a/src/trade/tradeConf.es6
+++ b/src/trade/tradeConf.es6
@@ -150,13 +150,13 @@ const register_ticks = (state, extra) => {
    let { tick_count } = extra;
    /* No need to worry about WS connection getting closed, because the user will be logged out */
    const add_tick  = (tick) => {
-      const is_or_after_contract_entry = (Number(tick.epoch)) >= proposal_open_contract.entry_tick_time;
-      const is_new_tick = !state.ticks.array.some((t) => t.epoch * 1 === tick.epoch * 1);
+      const is_or_after_contract_entry = (+tick.epoch) >= (+proposal_open_contract.entry_tick_time);
+      const is_new_tick = !state.ticks.array.some((state_tick) => state_tick.epoch * 1 === tick.epoch * 1);
       const should_add_new_tick = is_new_tick && !state.ticks.contract_is_finished && is_or_after_contract_entry;
 
       if (should_add_new_tick) {
-            const contract_is_finished = proposal_open_contract && proposal_open_contract.status !== 'open' && !state.ticks.contract_is_finished;
-            state.buy.barrier = proposal_open_contract && proposal_open_contract.barrier ? (+proposal_open_contract.barrier) : null;
+            const contract_is_finished = proposal_open_contract.status !== 'open' && !state.ticks.contract_is_finished;
+            state.buy.barrier = proposal_open_contract.barrier ? (+proposal_open_contract.barrier) : null;
 
             if (contract_is_finished) {
                   on_contract_finished(proposal_open_contract);


### PR DESCRIPTION
Refactor tick component:

* Add overlay to touch tick contracts
* Add addComma function (from binary-static)
* Add style (green/red background) after contract has finished (same as binary-static)

* Update number format for x, y-labels with addComma
* Change exit spot line to dashed

* Remove FE calculations for barrier
* Remove FE calculations for won/lost - use `status` from BE open contract response
* Remove FE calculations for Exit spot

* Use `entry_tick_time` as start time
* For `path dependent` contracts use `sell_spot` to determine exit spot else `exit_tick_time`
* Fix race condition between ticks stream and open proposal contract stream
