### PR TITLE
oskar/update_webtrader_charts_0.5.2

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -59,7 +59,7 @@ module.exports = function (grunt) {
                             "!highstock-release/**", "highstock-release/highstock.js", "highstock-release/themes/**", "highstock-release/modules/exporting.js", "highstock-release/modules/offline-exporting.js", "highstock-release/highcharts-more.js",
                             "moment/min/moment.min.js", "moment/locale/**",
                             "text/text.js",
-                            "webtrader-charts/dist/webtrader-charts.iife.js",
+                            "@binary-com/webtrader-charts/dist/webtrader-charts.iife.js",
                             "regenerator-runtime/*",
                             "!jquery-ui-dist/**", "jquery-ui-dist/jquery-ui.min.css", "jquery-ui-dist/jquery-ui.min.js",
                             "chosen-js/*",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "rivets": "0.8.1",
     "text": "requirejs/text",
     "vanderlee-colorpicker": "^1.2.13",
-    "webtrader-charts": "^0.4.12"
+    "@binary-com/webtrader-charts": "0.5.2"
   },
   "contributors": [
     {

--- a/src/charts/chartingRequestMap.es6
+++ b/src/charts/chartingRequestMap.es6
@@ -63,11 +63,15 @@ export const register = function(options) {
 
     const req = {
         "ticks_history": options.symbol,
-        "granularity": granularity,
         "count": options.count || 1,
         "end": 'latest',
         "style": style
     };
+
+    if (granularity) {
+        req.granularity = granularity;
+    }
+
     if (options.subscribe === 1) {
         req.subscribe = 1;
     }
@@ -149,7 +153,6 @@ export const unregister = function(key, containerIDWithHash) {
                 if(tickSubscribers)
                     map.register({
                         symbol: instrument,
-                        granularity: 0,
                         subscribe: 1,
                         count: 50 // To avoid missing any ticks.
                     });

--- a/src/charts/chartingRequestMap.es6
+++ b/src/charts/chartingRequestMap.es6
@@ -150,7 +150,7 @@ export const unregister = function(key, containerIDWithHash) {
             // Remove this part as well.
             .then(()=>{
                 // Resubscribe to tick stream if there are any tickSubscribers.
-                if(tickSubscribers)
+                if (tickSubscribers)
                     map.register({
                         symbol: instrument,
                         subscribe: 1,

--- a/src/main.js
+++ b/src/main.js
@@ -25,7 +25,7 @@ window.requirejs.config({
         "indicator_levels": "charts/indicators/level",
         "binary-style": "lib/binary-style/binary",
         "babel-runtime/regenerator": "lib/regenerator-runtime/runtime",
-        "webtrader-charts" : "lib/webtrader-charts/dist/webtrader-charts.iife",
+        "webtrader-charts" : "lib/@binary-com/webtrader-charts/dist/webtrader-charts.iife",
         "chosen": "lib/chosen-js/chosen.jquery",
         "highstock-release": "lib/highstock-release",
     },

--- a/src/trade/tradeDialog.es6
+++ b/src/trade/tradeDialog.es6
@@ -1047,7 +1047,6 @@ export function init(symbol, contracts_for, saved_template, isTrackerInitiated) 
         chartingRequestMap.register({
           symbol: symbol.symbol,
           subscribe: 1,
-          granularity: 0,
           style: 'ticks'
         }).catch(function (err) {
           /* if this contract offers tick trades, prevent user from trading */

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,17 @@
 # yarn lockfile v1
 
 
+"@binary-com/webtrader-charts@0.5.2":
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/@binary-com/webtrader-charts/-/webtrader-charts-0.5.2.tgz#8277e1c73a224051a2d460c8f439765dbd9e496a"
+  integrity sha512-Mxh0L/CCMgBP5saUA0FbbbNHUW4lHOto3IxQ2jjeLD3tToIIBeB8M/gY1uWeJnDYWe1nZler7ZCJYvPuyVPV6Q==
+  dependencies:
+    datatables.net-dt "^1.10.15"
+    imports-loader "^0.7.1"
+    lodash "^4.17.4"
+    paralleljs "^0.2.1"
+    rivets "0.8.1"
+
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
@@ -7470,17 +7481,6 @@ websocket-extensions@>=0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.3.tgz#5d2ff22977003ec687a4b87073dfbbac146ccf29"
   integrity sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==
-
-webtrader-charts@^0.4.12:
-  version "0.4.12"
-  resolved "https://registry.yarnpkg.com/webtrader-charts/-/webtrader-charts-0.4.12.tgz#086715470270753fc0226407c152111eaccb4e9d"
-  integrity sha1-CGcVRwJwdT/AImQHwVIRHqzLTp0=
-  dependencies:
-    datatables.net-dt "^1.10.15"
-    imports-loader "^0.7.1"
-    lodash "^4.17.4"
-    paralleljs "^0.2.1"
-    rivets "0.8.1"
 
 whet.extend@~0.9.9:
   version "0.9.9"


### PR DESCRIPTION
* Update to `@binary/webtrader-charts: 0.5.2`
* Resolve paths for webtrader-charts in grunt and main.js
* Remove granularity: 0 from chartingRequestMap and tradeDialog