### PR TITLE
Amam/min max copy

### DIFF
--- a/src/copytrade/copytrade.es6
+++ b/src/copytrade/copytrade.es6
@@ -44,7 +44,7 @@ const defaultTraderDetails = (traderApiToken, loginid) => ({
 
 const validate_min_max_stake = (yourCopySettingsData) => {
   const { min_trade_stake, max_trade_stake } = yourCopySettingsData;
-  if (min_trade_stake > max_trade_stake) {
+  if (+min_trade_stake > +max_trade_stake) {
     return false;
   }
   return true;


### PR DESCRIPTION
### avoid incorrect data types into passed `validate_min_max` function on copy trade
-- added `+` before variables