### PR TITLE
Mahdiyeh/fix: fix destroyed dialog error on workplace

### DIFF
--- a/src/windows/windows.es6
+++ b/src/windows/windows.es6
@@ -310,6 +310,7 @@ export const createBlankWindow = function ($html, options) {
       at: 'center',
       of: window,
       title: 'Blank window'.i18n(),
+      id: dialogCounter,
       icons: {
          close: 'custom-icon-close',
          minimize: 'custom-icon-minimize',
@@ -368,6 +369,10 @@ export const createBlankWindow = function ($html, options) {
             }, 300, dialog.trigger.bind(dialog, 'animated'));
          }
       });
+      if (options.title !== 'Manage') {
+         workspace.addDialog(options.title, options.id, blankWindow.moveToTop, () => blankWindow.dialog('close'));
+      }
+
    });
    blankWindow.moveToTop = () => {
       blankWindow.dialog('open');
@@ -379,11 +384,11 @@ export const createBlankWindow = function ($html, options) {
    const add_to_windows_menu = () => {
       const cleaner = () => {
          blankWindow.dialogExtend('restore');
-         workspace.addDialog(options.title, blankWindow.moveToTop, () => blankWindow.dialog('close'));
+         workspace.removeDialog(options.id);
       }
       blankWindow.on('dialogclose', cleaner);
-
    };
+   
    if (!options.ignoreTileAction) {
       add_to_windows_menu();
    }

--- a/src/workspace/workspace.es6
+++ b/src/workspace/workspace.es6
@@ -267,9 +267,10 @@ export const init = (parent) => {
    parent.append(root);
    rv.bind(root[0], state);
 }
-export const addDialog = (name, clickCb, removeCb) => {
+export const addDialog = (name, id, clickCb, removeCb) => {
    const row = {
       name: name,
+      id: id,
       click: () => {
         manager_win && manager_win.dialog('close');
         clickCb();
@@ -282,6 +283,10 @@ export const addDialog = (name, clickCb, removeCb) => {
    }
    state.dialogs.push(row);
    return cleaner;
+}
+
+export const removeDialog = (id) => {
+   state.dialogs = state.dialogs.filter( item => item.id !== id);
 }
 
 export const events = $('<div/>');
@@ -396,4 +401,4 @@ export const tileDialogs = () => {
    setTimeout(() => events.trigger('tile'), 1600);
 }
 
-export default { init, addDialog, events, tileDialogs };
+export default { init, addDialog, removeDialog, events, tileDialogs };


### PR DESCRIPTION
in the current version of webtrader we add destroyed dialog to the workplace table, so whenever we click on the table rows we get error which refers that this dialog is not initialized yet. In this PR the function `addDialog` is called on dialogOpen and `removeDialog` is called whenever the dialog get closed.