### PR TITLE
Change job dependency in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,7 +250,7 @@ workflows:
           context: binary-frontend-artifact-upload
       - publish_cloudflare_production:
           requires:
-            - release_aws_production
+            - release_production
           filters:
             branches:
               ignore: /.*/


### PR DESCRIPTION
# Changes
- `release_aws_production` is not persisting workspace